### PR TITLE
Add support for Gitea Actions

### DIFF
--- a/supportscolor.go
+++ b/supportscolor.go
@@ -210,7 +210,7 @@ func supportsColor(config *configuration) ColorLevel {
 	}
 
 	if _, ci := env.LookupEnv("CI"); ci {
-		var ciEnvNames = []string{"TRAVIS", "CIRCLECI", "APPVEYOR", "GITLAB_CI", "GITHUB_ACTIONS", "BUILDKITE", "DRONE"}
+		var ciEnvNames = []string{"TRAVIS", "CIRCLECI", "APPVEYOR", "GITLAB_CI", "GITHUB_ACTIONS", "GITEA_ACTIONS", "BUILDKITE", "DRONE"}
 		for _, ciEnvName := range ciEnvNames {
 			_, exists := env.LookupEnv(ciEnvName)
 			if exists {

--- a/supportscolor.go
+++ b/supportscolor.go
@@ -210,7 +210,15 @@ func supportsColor(config *configuration) ColorLevel {
 	}
 
 	if _, ci := env.LookupEnv("CI"); ci {
-		var ciEnvNames = []string{"TRAVIS", "CIRCLECI", "APPVEYOR", "GITLAB_CI", "GITHUB_ACTIONS", "GITEA_ACTIONS", "BUILDKITE", "DRONE"}
+    var trueColorEnvNames = []string{"GITHUB_ACTIONS", "GITEA_ACTIONS"}
+    for _, trueColorEnvName := range trueColorEnvNames {
+      _, exists := env.LookupEnv(trueColorEnvName)
+      if exists {
+        return Ansi16m
+      }
+    }
+
+		var ciEnvNames = []string{"TRAVIS", "CIRCLECI", "APPVEYOR", "GITLAB_CI", "BUILDKITE", "DRONE"}
 		for _, ciEnvName := range ciEnvNames {
 			_, exists := env.LookupEnv(ciEnvName)
 			if exists {

--- a/supportscolor_test.go
+++ b/supportscolor_test.go
@@ -292,7 +292,7 @@ func TestReturnBasicIfTravis(t *testing.T) {
 }
 
 func TestReturnBasicIfCI(t *testing.T) {
-	for _, ci := range []string{"CIRCLECI", "APPVEYOR", "GITLAB_CI", "BUILDKITE", "DRONE"} {
+	for _, ci := range []string{"CIRCLECI", "APPVEYOR", "GITLAB_CI", "GITHUB_ACTIONS", "GITEA_ACTIONS", "BUILDKITE", "DRONE"} {
 		result := SupportsColor(0, setEnvironment(&testEnvironment{
 			env: map[string]string{"CI": "true", ci: "true"},
 		}))

--- a/supportscolor_test.go
+++ b/supportscolor_test.go
@@ -291,8 +291,20 @@ func TestReturnBasicIfTravis(t *testing.T) {
 	}
 }
 
+func TestReturnTrueColorIfActions(t *testing.T) {
+  for _, ci := range []string{"GITHUB_ACTIONS", "GITEA_ACTIONS"} {
+    result := SupportsColor(0, setEnvironment(&testEnvironment{
+      env: map[string]string{"CI": "true", ci: "true"},
+    }))
+
+    if result.Level != Ansi16m {
+      t.Errorf("%v: Expected %v, got %v", ci, Ansi16m, result.Level)
+    }
+  }
+}
+
 func TestReturnBasicIfCI(t *testing.T) {
-	for _, ci := range []string{"CIRCLECI", "APPVEYOR", "GITLAB_CI", "GITHUB_ACTIONS", "GITEA_ACTIONS", "BUILDKITE", "DRONE"} {
+	for _, ci := range []string{"CIRCLECI", "APPVEYOR", "GITLAB_CI", "BUILDKITE", "DRONE"} {
 		result := SupportsColor(0, setEnvironment(&testEnvironment{
 			env: map[string]string{"CI": "true", ci: "true"},
 		}))


### PR DESCRIPTION
Add support for [Gitea Actions](https://docs.gitea.com/1.20/usage/actions/overview). Same as https://github.com/chalk/supports-color/pull/148.

Note that both environments support 16m colors and the JS module has it as that, but I opted to not change the return value, but if you like me to, I could mirror what the JS module does.